### PR TITLE
Open .torrent as binary, fix #4

### DIFF
--- a/drench/tparser.py
+++ b/drench/tparser.py
@@ -124,5 +124,5 @@ def bdecode_file(filename):
     '''
         Bdecodes a .torrent or other bencoded file
     '''
-    with open(filename) as f:
+    with open(filename, 'rb') as f:
         return bdecode(f.read())


### PR DESCRIPTION
Windows converts all LF into CRLF if file is read as text
